### PR TITLE
Fix oidc workflow

### DIFF
--- a/.github/workflows/deploy-push-oidc-master.yml
+++ b/.github/workflows/deploy-push-oidc-master.yml
@@ -6,7 +6,7 @@
 name: Deploy transformations using OIDC auth-flow
 
 on:
-    pull_request:
+    push:
         branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Why deploy in pull request? should not deploy before you merge with main no? also that messes with the branch-secret naming