### PR TITLE
fix: Enforce define cluster in deploy-push-main.yml

### DIFF
--- a/.github/workflows/deploy-push-main.yml
+++ b/.github/workflows/deploy-push-main.yml
@@ -41,7 +41,7 @@ jobs:
                   cdf-project-name: <my-cdf-project>
                   token-url: https://login.microsoftonline.com/<my-azure-tenant-id>/oauth2/v2.0/token
                   scopes: https://<my-cluster>.cognitedata.com/.default
-                  cluster: greenfield
+                  cluster: <my-cluster>
                   # Audience (for non AAD idps)
                   #audience: <audience>
 

--- a/.github/workflows/deploy-push-main.yml
+++ b/.github/workflows/deploy-push-main.yml
@@ -41,8 +41,7 @@ jobs:
                   cdf-project-name: <my-cdf-project>
                   token-url: https://login.microsoftonline.com/<my-azure-tenant-id>/oauth2/v2.0/token
                   scopes: https://<my-cluster>.cognitedata.com/.default
-                  # If you are not using the main cluster (europe-west1-1), specify it here:
-                  # cluster: greenfield
+                  cluster: greenfield
                   # Audience (for non AAD idps)
                   #audience: <audience>
 


### PR DESCRIPTION
Lets force the user to define the cluster. Most people do not use `europe-west1-1` as a cluster. It is also hard to spot this bug.