### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @cognitedata/r-alliance


### PR DESCRIPTION
Looks like github repo template don't work well with codeowners - cloned repo will have same codeowners which we don't need here. So let's drop codeowners